### PR TITLE
Clarify PMC decay factor documentation

### DIFF
--- a/services/pmc_metrics.py
+++ b/services/pmc_metrics.py
@@ -27,10 +27,13 @@ class PMCMetrics:
         
         Args:
             days: Number of days for the decay period
-            
+
         Returns:
-            Decay factor (typically 0.95 for CTL, 0.86 for ATL)
+            Decay factor (e.g., 0.98 for CTL, 0.87 for ATL)
         """
+        # Example outputs for common PMC periods:
+        # CTL decay factor for 42 days ~0.98
+        # ATL decay factor for 7 days  ~0.87
         return math.exp(-1 / days)
     
     def calculate_ctl(self, workouts: List[Dict], target_date: date) -> float:


### PR DESCRIPTION
## Summary
- Correct `calculate_decay_factor` docstring to reflect actual exponential decay for CTL and ATL
- Add sample decay factor comments for CTL (42 days) and ATL (7 days) to clarify expected outputs

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'calculate_pmc_metrics' from 'services.pmc_metrics')*

------
https://chatgpt.com/codex/tasks/task_e_68965c8fec008330aa4444faef380875