### PR TITLE
feat: add dark mode theme toggle

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,12 +2,12 @@
   display: flex;
   min-height: 100vh;
   font-family: 'Inter', Arial, sans-serif;
-  background: #f7fafc;
+  background: var(--color-bg);
 }
 
 .sidebar {
   width: 220px;
-  background: linear-gradient(135deg, #0f172a 80%, #06b6d4 100%);
+  background: linear-gradient(135deg, var(--sidebar-bg) 80%, var(--accent) 100%);
   color: #fff;
   display: flex;
   flex-direction: column;
@@ -21,7 +21,7 @@
   letter-spacing: 2px;
   margin-bottom: 2rem;
   text-align: center;
-  color: #06b6d4;
+  color: var(--accent);
 }
 
 .sidebar ul {
@@ -39,20 +39,41 @@
 }
 
 .sidebar-item:hover {
-  background: #164e63;
-  border-left: 4px solid #06b6d4;
+  background: var(--sidebar-hover);
+  border-left: 4px solid var(--accent);
 }
 
 .sidebar-item.active {
-  background: #164e63;
-  border-left: 4px solid #06b6d4;
-  color: #06b6d4;
+  background: var(--sidebar-hover);
+  border-left: 4px solid var(--accent);
+  color: var(--accent);
 }
 
 .main-content {
   flex: 1;
   padding: 48px;
-  background: #f7fafc;
+  background: var(--color-bg);
+}
+
+/* Top bar for utility actions */
+.top-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 32px;
+}
+
+.theme-toggle {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.theme-toggle:hover {
+  background: #0891b2;
 }
 
 /* Sync Data Styles */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2536,6 +2536,11 @@ function HealthAnalysis() {
 
 function App() {
   const [selectedItem, setSelectedItem] = useState('pmc');
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+  }, [darkMode]);
 
   const renderMainContent = () => {
     switch (selectedItem) {
@@ -2558,6 +2563,14 @@ function App() {
     <div className="app-container">
       <Sidebar selectedItem={selectedItem} onItemSelect={setSelectedItem} />
       <div className="main-content">
+        <div className="top-bar">
+          <button
+            className="theme-toggle"
+            onClick={() => setDarkMode(!darkMode)}
+          >
+            {darkMode ? 'Light Mode' : 'Dark Mode'}
+          </button>
+        </div>
         {renderMainContent()}
       </div>
     </div>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -25,6 +25,16 @@ Object.defineProperty(window, 'location', {
   writable: true,
 });
 
+describe('Theme toggle', () => {
+  test('switches between light and dark modes', () => {
+    render(<App />);
+    const toggle = screen.getByRole('button', { name: /dark mode/i });
+    expect(document.body).not.toHaveClass('dark');
+    fireEvent.click(toggle);
+    expect(document.body).toHaveClass('dark');
+  });
+});
+
 Object.defineProperty(window, 'history', {
   value: {
     replaceState: jest.fn(),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,24 @@
+/* Global theme variables */
+:root {
+  --color-bg: #f7fafc;
+  --color-text: #0f172a;
+  --sidebar-bg: #0f172a;
+  --sidebar-hover: #164e63;
+  --accent: #06b6d4;
+}
+
 body {
   margin: 0;
   padding: 0;
-  background: #f7fafc;
-} 
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+/* Dark theme overrides */
+body.dark {
+  --color-bg: #0f172a;
+  --color-text: #f1f5f9;
+  --sidebar-bg: #111827;
+  --sidebar-hover: #1e293b;
+  --accent: #0ea5e9;
+}


### PR DESCRIPTION
## Summary
- add global theme variables and dark mode support
- introduce top bar with theme toggle
- cover theme toggle with a React test

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*
- `pytest` *(fails: ImportError: cannot import name 'calculate_pmc_metrics')*

------
https://chatgpt.com/codex/tasks/task_e_68966205f358833089e4c0b586640d89