### PR TITLE
feat: add training plan designer

### DIFF
--- a/agents/training_plan_agent.py
+++ b/agents/training_plan_agent.py
@@ -1,0 +1,68 @@
+from datetime import date, timedelta
+from typing import List, Dict
+
+class TrainingPlanAgent:
+    """Simple rule-based agent to generate a training plan.
+
+    The implementation is intentionally modular so workout type templates
+    can easily be adjusted or extended.
+    """
+
+    WORKOUT_LIBRARY: Dict[str, str] = {
+        "easy_run": "Easy run in zone 2",
+        "long_run": "Long run building endurance",
+        "rest": "Rest or cross-training"
+    }
+
+    def generate_plan(
+        self,
+        start_date: date,
+        race_date: date,
+        workouts_per_week: int
+    ) -> List[Dict]:
+        """Generate a very simple training plan.
+
+        Args:
+            start_date: first day of the plan
+            race_date: target race day
+            workouts_per_week: maximum number of sessions per week
+
+        Returns:
+            List of session dictionaries with keys:
+            date, workout_type, description, phase
+        """
+        total_days = (race_date - start_date).days
+        total_weeks = max(total_days // 7, 1)
+
+        # Determine phase lengths (base, build, peak, taper)
+        phase_weeks = {
+            "base": max(int(total_weeks * 0.4), 1),
+            "build": max(int(total_weeks * 0.3), 1),
+            "peak": max(int(total_weeks * 0.2), 1),
+            "taper": max(total_weeks - sum(
+                [int(total_weeks * 0.4), int(total_weeks * 0.3), int(total_weeks * 0.2)]
+            ), 1),
+        }
+
+        sessions = []
+        current = start_date
+        for phase, weeks in phase_weeks.items():
+            for _ in range(weeks):
+                for day in range(workouts_per_week):
+                    # simple rotation: long run on day 0, easy otherwise
+                    if day == 0 and phase != "taper":
+                        wtype = "long_run"
+                    elif day == workouts_per_week - 1:
+                        wtype = "rest"
+                    else:
+                        wtype = "easy_run"
+                    sessions.append({
+                        "date": current,
+                        "workout_type": wtype,
+                        "description": self.WORKOUT_LIBRARY[wtype],
+                        "phase": phase,
+                    })
+                    current += timedelta(days=1)
+                # move to next week (skip remaining days)
+                current += timedelta(days=max(0, 7 - workouts_per_week))
+        return sessions

--- a/api/main.py
+++ b/api/main.py
@@ -22,6 +22,7 @@ from utils.exceptions import (
 )
 from utils.database import get_db_conn, get_athlete_uuid
 from services.pmc_metrics import pmc_metrics
+from agents.training_plan_agent import TrainingPlanAgent
 
 # Setup logging
 setup_logging(log_level="INFO", log_file="logs/app.log")
@@ -500,12 +501,36 @@ class WorkoutSummary(BaseModel):
     tss: Optional[float] = None
     duration_sec: Optional[int] = None
     duration_hr: Optional[float] = None
-    # Add more fields as needed for the frontend
+    description: Optional[str] = None
+    planned: bool = False
 
 class WorkoutDetail(WorkoutSummary):
     json_file: Optional[dict] = None
     csv_file: Optional[str] = None
     synced_at: Optional[str] = None
+
+
+class TrainingPlanInput(BaseModel):
+    athlete_id: str
+    race_date: str
+    race_type: str
+    max_workouts_per_week: int
+
+
+class TrainingSessionOut(BaseModel):
+    id: str
+    date: str
+    workout_type: str
+    description: Optional[str] = None
+    phase: Optional[str] = None
+
+
+class TrainingPlanOut(BaseModel):
+    plan_id: str
+    race_date: str
+    race_type: str
+    max_workouts_per_week: int
+    sessions: List[TrainingSessionOut]
 
 @app.get("/api/workouts", response_model=List[WorkoutSummary])
 def get_workouts(
@@ -538,17 +563,135 @@ def get_workouts(
                 """,
                 (athlete_uuid, start_date, end_date)
             )
-            rows = cur.fetchall()
+            workout_rows = cur.fetchall()
+
+            cur.execute(
+                """
+                SELECT id, athlete_id, session_date, workout_type, planned_tss, description
+                FROM training_session
+                WHERE athlete_id = %s AND session_date BETWEEN %s AND %s
+                ORDER BY session_date ASC
+                """,
+                (athlete_uuid, start_date, end_date)
+            )
+            session_rows = cur.fetchall()
+
             result = []
-            for row in rows:
+            for row in workout_rows:
                 result.append(WorkoutSummary(
                     id=row[0],
                     athlete_id=row[1],
                     timestamp=row[2].isoformat() if hasattr(row[2], 'isoformat') else str(row[2]),
                     workout_type=row[3],
                     tss=row[4],
+                    planned=False
                 ))
+            for row in session_rows:
+                result.append(WorkoutSummary(
+                    id=row[0],
+                    athlete_id=row[1],
+                    timestamp=row[2].isoformat() if hasattr(row[2], 'isoformat') else str(row[2]),
+                    workout_type=row[3],
+                    tss=row[4],
+                    description=row[5],
+                    planned=True
+                ))
+
+            result.sort(key=lambda w: w.timestamp)
             return result
+
+@app.post("/api/training-plan", response_model=TrainingPlanOut)
+def create_training_plan(plan: TrainingPlanInput):
+    """Generate a training plan and persist sessions."""
+    start_date = dt.date.today()
+    race_date = dt.date.fromisoformat(plan.race_date)
+    agent = TrainingPlanAgent()
+    sessions = agent.generate_plan(start_date, race_date, plan.max_workouts_per_week)
+
+    with get_db_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO training_plan (athlete_id, race_date, race_type, max_workouts_per_week)
+                VALUES (%s, %s, %s, %s) RETURNING id
+                """,
+                (plan.athlete_id, plan.race_date, plan.race_type, plan.max_workouts_per_week)
+            )
+            plan_id = cur.fetchone()[0]
+            session_out: List[TrainingSessionOut] = []
+            for s in sessions:
+                cur.execute(
+                    """
+                    INSERT INTO training_session (plan_id, athlete_id, session_date, workout_type, description, phase)
+                    VALUES (%s, %s, %s, %s, %s, %s) RETURNING id
+                    """,
+                    (plan_id, plan.athlete_id, s["date"], s["workout_type"], s["description"], s["phase"])
+                )
+                sid = cur.fetchone()[0]
+                session_out.append(TrainingSessionOut(
+                    id=sid,
+                    date=s["date"].isoformat(),
+                    workout_type=s["workout_type"],
+                    description=s["description"],
+                    phase=s["phase"]
+                ))
+            conn.commit()
+
+    return TrainingPlanOut(
+        plan_id=plan_id,
+        race_date=plan.race_date,
+        race_type=plan.race_type,
+        max_workouts_per_week=plan.max_workouts_per_week,
+        sessions=session_out
+    )
+
+
+@app.get("/api/training-plan", response_model=TrainingPlanOut)
+def get_training_plan(athlete_id: str):
+    """Return latest training plan for an athlete."""
+    with get_db_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, race_date, race_type, max_workouts_per_week
+                FROM training_plan
+                WHERE athlete_id = %s
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (athlete_id,)
+            )
+            plan_row = cur.fetchone()
+            if not plan_row:
+                raise HTTPException(status_code=404, detail="Training plan not found")
+            plan_id = plan_row[0]
+            cur.execute(
+                """
+                SELECT id, session_date, workout_type, description, phase
+                FROM training_session
+                WHERE plan_id = %s
+                ORDER BY session_date ASC
+                """,
+                (plan_id,)
+            )
+            sessions = [
+                TrainingSessionOut(
+                    id=r[0],
+                    date=r[1].isoformat() if hasattr(r[1], 'isoformat') else str(r[1]),
+                    workout_type=r[2],
+                    description=r[3],
+                    phase=r[4]
+                )
+                for r in cur.fetchall()
+            ]
+
+    return TrainingPlanOut(
+        plan_id=plan_id,
+        race_date=plan_row[1].isoformat() if hasattr(plan_row[1], 'isoformat') else str(plan_row[1]),
+        race_type=plan_row[2],
+        max_workouts_per_week=plan_row[3],
+        sessions=sessions
+    )
 
 @app.get("/api/workouts/{workout_id}", response_model=WorkoutDetail)
 def get_workout_detail(workout_id: str):

--- a/database/init/006_create_training_plan.sql
+++ b/database/init/006_create_training_plan.sql
@@ -1,0 +1,22 @@
+-- 006_create_training_plan.sql
+-- Tables for generated training plans and individual sessions
+
+CREATE TABLE IF NOT EXISTS training_plan (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    athlete_id UUID REFERENCES athlete(id) ON DELETE CASCADE,
+    race_date DATE NOT NULL,
+    race_type TEXT NOT NULL,
+    max_workouts_per_week INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS training_session (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    plan_id UUID REFERENCES training_plan(id) ON DELETE CASCADE,
+    athlete_id UUID REFERENCES athlete(id) ON DELETE CASCADE,
+    session_date DATE NOT NULL,
+    workout_type TEXT NOT NULL,
+    description TEXT,
+    phase TEXT,
+    planned_tss FLOAT
+);

--- a/database_schema.md
+++ b/database_schema.md
@@ -90,3 +90,28 @@ Stores time-series or summary data for each workout.
 | `value` | Float | The value of the metric. |
 | `unit` | String | The unit of measurement. |
 | `timestamp` | DateTime | Timestamp for time-series data; null for summary. | 
+#### 7. **`training_plan`**
+Stores high level information about a generated plan.
+
+| Column | Data Type | Description |
+| :--- | :--- | :--- |
+| `id` | UUID (PK) | Unique identifier for the plan. |
+| `athlete_id` | UUID (FK) | References `athlete.id`. |
+| `race_date` | Date | Target race date. |
+| `race_type` | Text | Type of event (e.g., marathon, ironman). |
+| `max_workouts_per_week` | Integer | Maximum sessions per week. |
+| `created_at` | Timestamp | Creation time. |
+
+#### 8. **`training_session`**
+Individual sessions belonging to a training plan.
+
+| Column | Data Type | Description |
+| :--- | :--- | :--- |
+| `id` | UUID (PK) | Unique identifier for the session. |
+| `plan_id` | UUID (FK) | References `training_plan.id`. |
+| `athlete_id` | UUID (FK) | References `athlete.id`. |
+| `session_date` | Date | Scheduled date of the session. |
+| `workout_type` | Text | Workout modality/type. |
+| `description` | Text | Human readable session description. |
+| `phase` | Text | Macro phase (base, build, peak, taper). |
+| `planned_tss` | Float | Optional planned TSS. |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1013,6 +1013,37 @@ body.modal-open {
   color: #555;
   margin-right: 8px;
 }
+.workout-item.planned {
+  background: #fff4e6;
+  cursor: default;
+}
+.planned-label {
+  font-size: 0.8em;
+  color: #e67e22;
+  margin-left: 4px;
+}
+.workout-desc {
+  font-size: 0.9em;
+  color: #555;
+}
+
+.training-plan-container {
+  padding: 20px;
+}
+.training-plan-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 300px;
+}
+.training-plan-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9em;
+}
+.plan-message {
+  margin-top: 10px;
+}
 .no-workout {
   color: #bbb;
 }


### PR DESCRIPTION
## Summary
- add rule-based training plan agent and schema
- expose training plan API endpoints and mix planned sessions with workouts
- add frontend training plan form and display planned sessions

## Testing
- `pytest` *(fails: ProxyError ... 42 failed, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68978b6c85888330b8cee398c5cde2a5